### PR TITLE
Circumvent "Unknown CA" error during authorisation

### DIFF
--- a/lib/fluminus/http_client.ex
+++ b/lib/fluminus/http_client.ex
@@ -61,7 +61,7 @@ defmodule Fluminus.HTTPClient do
       when method in @supported_methods and is_binary(url) and is_binary(body) and is_list(headers) do
     headers = generate_headers(client, headers)
 
-    case HTTPoison.request(method, url, body, headers, recv_timeout: 10_000) do
+    case HTTPoison.request(method, url, body, headers, recv_timeout: 10_000, hackney: [:insecure]) do
       {:ok, response = %HTTPoison.Response{headers: headers}} ->
         updated_client = update_cookies(client, response)
         flattened_headers = headers |> Enum.map(fn {key, value} -> {String.downcase(key), value} end) |> Map.new()

--- a/lib/fluminus/http_client.ex
+++ b/lib/fluminus/http_client.ex
@@ -61,7 +61,7 @@ defmodule Fluminus.HTTPClient do
       when method in @supported_methods and is_binary(url) and is_binary(body) and is_list(headers) do
     headers = generate_headers(client, headers)
 
-    case HTTPoison.request(method, url, body, headers, recv_timeout: 10_000, hackney: [:insecure]) do
+    case HTTPoison.request(method, url, body, headers, recv_timeout: 10_000, ssl: [cacerts: :certifi.cacerts()]) do
       {:ok, response = %HTTPoison.Response{headers: headers}} ->
         updated_client = update_cookies(client, response)
         flattened_headers = headers |> Enum.map(fn {key, value} -> {String.downcase(key), value} end) |> Map.new()

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,7 @@ defmodule Fluminus.MixProject do
       {:html_entities, "~> 0.4"},
       {:html_sanitize_ex, "~> 1.4.0"},
       {:httpoison, "~> 1.4"},
+      {:certifi, "~> 2.5"},
       {:jason, "~> 1.1"},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:credo, "~> 1.5.0", only: :test, runtime: false},


### PR DESCRIPTION
## Short Excerpt
Authorization fails with `Unknown CA` error. Added `hackney: [:insecure]` parameter into HTTPoison call in order to circumvent.

## Long Story
For some strange reason, the authorisation is unable to go through with the following error:
```
04:36:05.294 [info]  TLS :client: In state :certify at ssl_handshake.erl:1950 generated CLIENT ALERT: Fatal - Unknown CA

{:error,
 %HTTPoison.Error{
   id: nil,
   reason: {:tls_alert,
    {:unknown_ca,
     'TLS client: In state certify at ssl_handshake.erl:1950 generated CLIENT ALERT: Fatal - Unknown CA\n'}}
 }}
```
The error is not likely to be caused by incorrect credential due to the fact that:
- Purposedly inputting an wrong password produces `{:error, :invalid_credentials}` rather than the TLS handshake error.
- Use curl to send the very same POST request with intercepted token from `authorization.ex:68` without `-k` option produces
```
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```
- Adding the `-k` option allows curl to return the responded token without problem.

## Reproducing
With the environment of Ubuntu 18.04.5 LTS, Erlang 23.1.5, and Elixir 1.11.2, the mere operation of invoking `vafs_jwt` function should be enough to reproduce this behaviour.

---
*(Sorry if the PR is much too spammy or otherwise bizarre in any way…… I'm a freshman without very much of a technical background if any at all :-C)*
